### PR TITLE
Change scene and route in one pass

### DIFF
--- a/Sources/SceneCoordinator.swift
+++ b/Sources/SceneCoordinator.swift
@@ -8,11 +8,24 @@
 
 import UIKit
 
+/// A SceneCoordinator can manage the transition between disparate coordinators.
+/// For instance, if the coordinator has three child scenes, A, B, and C, then 
+/// the scene coordinator can manage switching between them, showing only one at a time,
+/// as well as routing the subroute to the current scene (either A, B, or C).
+/// 
+/// To do this, it wants a route prefix to indicate which scene should be shown, and
+/// a currentScene property to know which scene to route to.
 public protocol SceneCoordinator: Coordinator {
+    /// The route prefix that indicates the current scene.
     var scenePrefix: String? { get }
+
+    /// The current scene being shown by the coordinator.
     var currentScene: AnyCoordinator? { get }
+
+    /// Conforming types must implement this method in order to perform the view level
+    /// work to transition from one scene to another. It is expected that the new scene
+    /// will be initialized to show the current route passed.
     func changeScene(_ route: Route)
-    func sceneRoute(_ route: Route) -> Route
 }
 
 public extension SceneCoordinator {
@@ -25,8 +38,9 @@ public extension SceneCoordinator {
             let r = route
             if r.first != newValue.first {
                 changeScene(newValue)
+            } else {
+                routeScene(newValue)
             }
-            routeScene(newValue)
         }
     }
 


### PR DESCRIPTION
This fixes issues that come up where routes are changed by child
coordinators during the change scene process.

For instance, if A and B are scene coordinators, and A is the parent
of B, if B updates its route on start to go to a specific child, then
we have a problem with the old two step pass. One scenario we saw
looks like this:

- route = "b"
- A's route set:
  - change scene for route "b"
- A's change scene:
  - set current scene to B
  - B.start()
- B's start:
  - dispatch action to update route to "b/c"
- B's route set:
  - change scene for subroute "c"
  - route current scene for ""
- A's original route set:
  - route current scene to ""
- B's route set:
  - change scene for subroute ""

A's original route set has effectively undone the changes that B has made.
For this reason, changing scenes and updating routes should be done in one
pass.