### PR TITLE
Add support for presenting a modal on new coordinator

### DIFF
--- a/Sources/Coordinator.swift
+++ b/Sources/Coordinator.swift
@@ -60,3 +60,13 @@ public protocol Coordinator: AnyCoordinator {
     associatedtype State: StateType
     var store: Store<State> { get }
 }
+
+public func wrapPresentingCompletionHandler(coordinator: AnyCoordinator, completionHandler: @escaping () -> Void) -> () -> Void {
+    guard let coordinator = coordinator as? AnyPresentingCoordinator, coordinator.hasStoredPresentable else {
+        return completionHandler
+    }
+
+    return {
+        coordinator.presentStoredPresentable(completionHandler: completionHandler)
+    }
+}

--- a/Sources/SceneCoordinator.swift
+++ b/Sources/SceneCoordinator.swift
@@ -52,7 +52,7 @@ public extension SceneCoordinator {
             if let coordinator = coordinatorForTag(tag) {
                 currentScene = Scene(tag: tag, coordinator: coordinator)
                 coordinator.start(route: sceneRoute(route))
-                presentCoordinator(coordinator, completionHandler: completionHandler)
+                presentCoordinator(coordinator, completionHandler: wrapPresentingCompletionHandler(coordinator: coordinator, completionHandler: completionHandler))
             } else {
                 presentCoordinator(nil, completionHandler: completionHandler)
             }

--- a/Sources/TabBarControllerCoordinator.swift
+++ b/Sources/TabBarControllerCoordinator.swift
@@ -41,6 +41,7 @@ public extension TabBarControllerCoordinator {
         }
 
         tabBarController.selectedIndex = scenes.index(where: { $0.coordinator === coordinator }) ?? 0
+        completionHandler()
     }
 
     public func setRouteForViewController(_ viewController: UIViewController) -> Bool {


### PR DESCRIPTION
It is possible that the route passed to a new PresentingCoordinator's
start method includes a modal element that should be immediately
presented.

This commit adds the functionality to do so:

- The scene to present is stored
- Adds helper methods to present the stored scene
- Automatically presents the stored scene from SceneCoordinators