### PR TITLE
Remove unsubscribe generic constraint

### DIFF
--- a/CorduxTests/SubscriptionsTest.swift
+++ b/CorduxTests/SubscriptionsTest.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-import Cordux
+@testable import Cordux
 
 class SubscriptionTestsSubscriber: SubscriberType {
     var lastModel: SimpleAuthViewModel?
@@ -42,4 +42,14 @@ class SubscriptionsTest: XCTestCase {
     }
 
 
+    func testUnsubscription() {
+        let sub = SubscriptionTestsSubscriber()
+        XCTAssert(store.isNewSubscriber(sub))
+
+        store.subscribe(sub, SimpleAuthViewModel.init)
+        XCTAssert(!store.isNewSubscriber(sub))
+
+        store.unsubscribe(sub)
+        XCTAssert(store.isNewSubscriber(sub))
+    }
 }

--- a/Sources/Store.swift
+++ b/Sources/Store.swift
@@ -65,14 +65,14 @@ public final class Store<State : StateType> {
         }
     #endif
 
-    public func unsubscribe<Subscriber : AnyStoreSubscriber>(_ subscriber: Subscriber) {
+    public func unsubscribe(_ subscriber: AnyStoreSubscriber) {
         #if swift(>=3)
             if let index = subscriptions.index(where: { return $0.subscriber === subscriber }) {
-            subscriptions.remove(at: index)
+                subscriptions.remove(at: index)
             }
         #else
-            if let index = subscriptions.indexOf({ return $0.subscriber === subscriber }) {
-                subscriptions.removeAtIndex(index)
+            if let index = subscriptions.index(where: { return $0.subscriber === subscriber }) {
+            subscriptions.remove(at: index)
             }
         #endif
     }


### PR DESCRIPTION
Remove the generic constraint requirement for Store.unsubscribe(..)
to allow any AnyStoreSubscriber conforming object to be passed in.